### PR TITLE
build(Maven): Fix SCM metadata in the parent POM

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -75,9 +75,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git@github.com:nordic-institute/xrd4j.git</connection>
+        <connection>scm:git:https://github.com/nordic-institute/xrd4j.git</connection>
         <developerConnection>scm:git:git@github.com:nordic-institute/xrd4j.git</developerConnection>
-        <url>git@github.com:nordic-institute/xrd4j.git</url>
+        <url>https://github.com/nordic-institute/xrd4j</url>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
The `connection` is only supposed to require read-access and ideally can be used anonymously, so use HTTPS instead SSH as a Git transport. The `url` should point to "A publicly browsable repository", not a Git clone URL, so fix this as well. See [1] for context.

[1]: https://maven.apache.org/pom.html#SCM