### PR TITLE
Added operations to example-adapter for soap attachments testing

### DIFF
--- a/example-adapter/README.md
+++ b/example-adapter/README.md
@@ -151,3 +151,27 @@ curl -d @examples/personDetailsRequest.xml --header "Content-Type: text/xml" -X 
 ```
 
 An example of the corresponding [SOAP response](examples/personDetailsResponse.xml) (available in the `examples` directory).
+
+### storeAttachments
+
+An example [multipart MIME request](examples/storeAttachmentsRequest.txt) (available in the `examples` directory).
+
+At the project root, the following command will call `storeAttachments`:
+
+```bash
+curl -X POST -H "Content-Type: multipart/related; start=\"<rootpart>\"; boundary=MIME_boundary" --data-binary @examples/storeAttachmentsRequest.txt -X POST http://localhost:8080/example-adapter/Endpoint
+```
+
+An example of the corresponding [SOAP response](examples/storeAttachmentsResponse.xml) (available in the `examples` directory).
+
+### getAttachments
+
+An example [SOAP request](examples/getAttachmentsRequest.xml) (available in the `examples` directory).
+
+At the project root, the following command will call `getAttachments`:
+
+```bash
+curl -d @examples/getAttachmentsRequest.xml --header "Content-Type: text/xml" -X POST http://localhost:8080/example-adapter/Endpoint
+```
+
+The response is multipart MIME message containing SOAP response and attachments. An example of the corresponding [response](examples/getAttachmentsResponse.txt) (available in the `examples` directory).

--- a/example-adapter/examples/getAttachmentsRequest.xml
+++ b/example-adapter/examples/getAttachmentsRequest.xml
@@ -1,0 +1,28 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xro="http://x-road.eu/xsd/xroad.xsd" xmlns:iden="http://x-road.eu/xsd/identifiers" >
+    <soapenv:Header>
+        <xro:client iden:objectType="SUBSYSTEM">
+            <iden:xRoadInstance>FI_TEST</iden:xRoadInstance>
+            <iden:memberClass>GOV</iden:memberClass>
+            <iden:memberCode>1234567-8</iden:memberCode>
+            <iden:subsystemCode>TestClient</iden:subsystemCode>
+        </xro:client>
+        <xro:service iden:objectType="SERVICE">
+            <iden:xRoadInstance>FI_TEST</iden:xRoadInstance>
+            <iden:memberClass>GOV</iden:memberClass>
+            <iden:memberCode>9876543-1</iden:memberCode>
+            <iden:subsystemCode>DemoService</iden:subsystemCode>
+            <iden:serviceCode>getAttachments</iden:serviceCode>
+            <iden:serviceVersion>v1</iden:serviceVersion>
+        </xro:service>
+        <xro:id>ID11234</xro:id>
+        <xro:userId>EE1234567890</xro:userId>
+        <xro:protocolVersion>4.0</xro:protocolVersion>
+    </soapenv:Header>
+    <soapenv:Body>
+        <prod:getAttachments xmlns:prod="http://test.x-road.global/producer">
+            <!--1 or more repetitions:-->
+            <prod:size>100</prod:size>
+            <prod:size>50</prod:size>
+        </prod:getAttachments>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/example-adapter/examples/getAttachmentsResponse.txt
+++ b/example-adapter/examples/getAttachmentsResponse.txt
@@ -1,0 +1,54 @@
+HTTP/1.1 200
+Content-Type: multipart/related;type="text/xml";boundary="----=_Part_1_1233349898.1717673591032";charset=UTF-8
+Content-Length: 1926
+Date: Thu, 06 Jun 2024 11:33:11 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive
+
+------=_Part_1_1233349898.1717673591032
+Content-Type: text/xml; charset=utf-8
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:iden="http://x-road.eu/xsd/identifiers" xmlns:xro="http://x-road.eu/xsd/xroad.xsd">
+    <soapenv:Header>
+        <xro:client iden:objectType="SUBSYSTEM">
+            <iden:xRoadInstance>FI_TEST</iden:xRoadInstance>
+            <iden:memberClass>GOV</iden:memberClass>
+            <iden:memberCode>1234567-8</iden:memberCode>
+            <iden:subsystemCode>TestClient</iden:subsystemCode>
+        </xro:client>
+        <xro:service iden:objectType="SERVICE">
+            <iden:xRoadInstance>FI_TEST</iden:xRoadInstance>
+            <iden:memberClass>GOV</iden:memberClass>
+            <iden:memberCode>9876543-1</iden:memberCode>
+            <iden:subsystemCode>DemoService</iden:subsystemCode>
+            <iden:serviceCode>getAttachments</iden:serviceCode>
+            <iden:serviceVersion>v1</iden:serviceVersion>
+        </xro:service>
+        <xro:id>ID11234</xro:id>
+        <xro:userId>EE1234567890</xro:userId>
+        <xro:protocolVersion>4.0</xro:protocolVersion>
+    </soapenv:Header>
+    <soapenv:Body>
+        <ts1:getAttachmentsResponse xmlns:ts1="http://test.x-road.global/producer">
+            <ts1:attachment>
+                <ts1:name>attachment_0_100</ts1:name>
+                <ts1:size>100</ts1:size>
+            </ts1:attachment>
+            <ts1:attachment>
+                <ts1:name>attachment_1_50</ts1:name>
+                <ts1:size>50</ts1:size>
+            </ts1:attachment>
+        </ts1:getAttachmentsResponse>
+    </soapenv:Body>
+</soapenv:Envelope>
+------=_Part_1_1233349898.1717673591032
+Content-Type: application/octet-stream
+Content-ID: attachment_0_100
+
+gtwunexdnrkgpyywdflxsfvuvsbgzmwwwllgwlutnqxpgkurdokgvreypgbkbnwdepsvbbqqnofydkwoinlwmlxejttvcmrpcwkb
+------=_Part_1_1233349898.1717673591032
+Content-Type: application/octet-stream
+Content-ID: attachment_1_50
+
+juyjrkrizxziugllsjujasxwyadymwssrbndulsojmxvpjcqws
+------=_Part_1_1233349898.1717673591032--

--- a/example-adapter/examples/storeAttachmentsRequest.txt
+++ b/example-adapter/examples/storeAttachmentsRequest.txt
@@ -1,0 +1,47 @@
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: <rootpart>
+
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:id="http://x-road.eu/xsd/identifiers" xmlns:xrd="http://x-road.eu/xsd/xroad.xsd">
+    <SOAP-ENV:Header>
+        <xrd:client id:objectType="SUBSYSTEM">
+            <id:xRoadInstance>FI_TEST</id:xRoadInstance>
+            <id:memberClass>GOV</id:memberClass>
+            <id:memberCode>1234567-8</id:memberCode>
+            <id:subsystemCode>TestClient</id:subsystemCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>FI_TEST</id:xRoadInstance>
+            <id:memberClass>GOV</id:memberClass>
+            <id:memberCode>9876543-1</id:memberCode>
+            <id:subsystemCode>DemoService</id:subsystemCode>
+            <id:serviceCode>storeAttachments</id:serviceCode>
+            <id:serviceVersion>v1</id:serviceVersion>
+        </xrd:service>
+        <xrd:id>ID11234</xrd:id>
+        <xrd:userId>EE1234567890</xrd:userId>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <prod:storeAttachments xmlns:prod="http://test.x-road.global/producer"/>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+
+--MIME_boundary
+Content-Type: application/octet-stream; name=attachment-1
+Content-Transfer-Encoding: binary
+Content-ID: attachment-1
+Content-Disposition: attachment; name="attachment-1"; filename="attachment-1"
+
+attachment 1 content
+
+--MIME_boundary
+Content-Type: application/octet-stream; name=attachment-2
+Content-Transfer-Encoding: binary
+Content-ID: attachment-2
+Content-Disposition: attachment; name="attachment-2"; filename="attachment-2"
+
+attachment 2
+
+--MIME_boundary--

--- a/example-adapter/examples/storeAttachmentsResponse.xml
+++ b/example-adapter/examples/storeAttachmentsResponse.xml
@@ -1,0 +1,33 @@
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:id="http://x-road.eu/xsd/identifiers" xmlns:xrd="http://x-road.eu/xsd/xroad.xsd">
+    <SOAP-ENV:Header>
+        <xrd:client id:objectType="SUBSYSTEM">
+            <id:xRoadInstance>FI_TEST</id:xRoadInstance>
+            <id:memberClass>GOV</id:memberClass>
+            <id:memberCode>1234567-8</id:memberCode>
+            <id:subsystemCode>TestClient</id:subsystemCode>
+        </xrd:client>
+        <xrd:service id:objectType="SERVICE">
+            <id:xRoadInstance>FI_TEST</id:xRoadInstance>
+            <id:memberClass>GOV</id:memberClass>
+            <id:memberCode>9876543-1</id:memberCode>
+            <id:subsystemCode>DemoService</id:subsystemCode>
+            <id:serviceCode>storeAttachments</id:serviceCode>
+            <id:serviceVersion>v1</id:serviceVersion>
+        </xrd:service>
+        <xrd:id>ID11234</xrd:id>
+        <xrd:userId>EE1234567890</xrd:userId>
+        <xrd:protocolVersion>4.0</xrd:protocolVersion>
+    </SOAP-ENV:Header>
+    <SOAP-ENV:Body>
+        <ts1:storeAttachmentsResponse xmlns:ts1="http://test.x-road.global/producer">
+            <ts1:attachment>
+                <ts1:name>attachment-1</ts1:name>
+                <ts1:size>21</ts1:size>
+            </ts1:attachment>
+            <ts1:attachment>
+                <ts1:name>attachment-2</ts1:name>
+                <ts1:size>13</ts1:size>
+            </ts1:attachment>
+        </ts1:storeAttachmentsResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/example-adapter/pom.xml
+++ b/example-adapter/pom.xml
@@ -21,7 +21,7 @@
         <version>2.7.9</version>
     </parent>
     <properties>
-        <xrd4j.version>0.4.0</xrd4j.version>
+        <xrd4j.version>0.5.0-SNAPSHOT</xrd4j.version>
         <slf4j.version>2.0.6</slf4j.version>
         <jdk.version>1.8</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/example-adapter/src/main/resources/example-adapter.wsdl
+++ b/example-adapter/src/main/resources/example-adapter.wsdl
@@ -215,6 +215,36 @@
                     </xsd:enumeration>
                 </xsd:restriction>
             </xsd:simpleType>
+            <xsd:element name="storeAttachments">
+                <xsd:complexType />
+            </xsd:element>
+            <xsd:element name="storeAttachmentsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="attachment" maxOccurs="unbounded" type="tns:attachmentType"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="getAttachments">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="size" type="xsd:positiveInteger" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="getAttachmentsResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="attachment" maxOccurs="unbounded" type="tns:attachmentType"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:complexType name="attachmentType">
+                <xsd:sequence>
+                    <xsd:element name="name" type="xsd:string"/>
+                    <xsd:element name="size" type="xsd:positiveInteger"/>
+                </xsd:sequence>
+            </xsd:complexType>
         </xsd:schema>
     </wsdl:types>
 
@@ -253,6 +283,18 @@
         <wsdl:part name="personDetailsResponse"
                    element="tns:personDetailsResponse"/>
     </wsdl:message>
+    <wsdl:message name="storeAttachments">
+        <wsdl:part name="storeAttachments" element="tns:storeAttachments"/>
+    </wsdl:message>
+    <wsdl:message name="storeAttachmentsResponse">
+        <wsdl:part name="storeAttachmentsResponse" element="tns:storeAttachmentsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="getAttachments">
+        <wsdl:part name="getAttachments" element="tns:getAttachments"/>
+    </wsdl:message>
+    <wsdl:message name="getAttachmentsResponse">
+        <wsdl:part name="getAttachmentsResponse" element="tns:getAttachmentsResponse"/>
+    </wsdl:message>
 
     <wsdl:portType name="testServicePortType">
         <wsdl:operation name="getRandom">
@@ -290,6 +332,14 @@
             <wsdl:input name="personDetails" message="tns:personDetails"/>
             <wsdl:output name="personDetailsResponse"
                          message="tns:personDetailsResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="storeAttachments">
+            <wsdl:input name="storeAttachments" message="tns:storeAttachments"/>
+            <wsdl:output name="storeAttachmentsResponse" message="tns:storeAttachmentsResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="getAttachments">
+            <wsdl:input name="getAttachments" message="tns:getAttachments"/>
+            <wsdl:output name="getAttachmentsResponse" message="tns:getAttachmentsResponse"/>
         </wsdl:operation>
     </wsdl:portType>
 
@@ -393,6 +443,74 @@
                              part="protocolVersion" use="literal"/>
             </wsdl:input>
             <wsdl:output name="personDetailsResponse">
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="client" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="service" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="id" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="userId" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="issue" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="protocolVersion" use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="storeAttachments">
+            <soap:operation soapAction="" style="document"/>
+            <xrd:version>v1</xrd:version>
+            <wsdl:input name="storeAttachments">
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="client" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="service" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="id" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="userId" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="issue" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="protocolVersion" use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="storeAttachmentsResponse">
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="client" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="service" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="id" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="userId" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="issue" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="protocolVersion" use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="getAttachments">
+            <soap:operation soapAction="" style="document"/>
+            <xrd:version>v1</xrd:version>
+            <wsdl:input name="getAttachments">
+                <soap:body use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="client" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="service" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="id" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="userId" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="issue" use="literal"/>
+                <soap:header message="tns:requestHeader"
+                             part="protocolVersion" use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="getAttachmentsResponse">
                 <soap:body use="literal"/>
                 <soap:header message="tns:requestHeader"
                              part="client" use="literal"/>

--- a/src/common/src/main/java/org/niis/xrd4j/common/util/SOAPHelper.java
+++ b/src/common/src/main/java/org/niis/xrd4j/common/util/SOAPHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright © 2018 Nordic Institute for Interoperability Solutions (NIIS)
  *
@@ -699,14 +699,11 @@ public final class SOAPHelper {
      * @return cloned SOAP message with empty SOAP body
      */
     public static SOAPMessage cloneSOAPMsgWithoutBody(SOAPMessage source) {
-        SOAPMessage target = toSOAP(toString(source));
-        if (target == null) {
-            LOGGER.debug("Cloned SOAP message is null.");
-            return null;
-        }
         try {
-            target.getSOAPBody().removeContents();
-            return target;
+            SOAPMessage msg = createSOAPMessage();
+            msg.getSOAPPart().setContent(source.getSOAPPart().getContent());
+            msg.getSOAPBody().removeContents();
+            return msg;
         } catch (SOAPException ex) {
             LOGGER.error(ex.getMessage(), ex);
             return null;


### PR DESCRIPTION
- Added operations to example-adapter for soap attachments testing.
- Fixed issue when empty response is returned from example adapter if request contains attachments.