### PR TITLE
Improve generics definitions on SOAPClient and LoadBalancedSOAPClient metaservice and send function definitions

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 - unreleased
+- Improved generics support on `SOAPClient` and `LoadBalancedSOAPCLient`
+- Marked constructors that should no longer be used as `@Deprecated` in `ProducerMember`
+
 ## 0.8.0 - 2025-06-03
 - XRDDEV-2911 Fix issue with SOAPHelper.removeNamespaces
 - **Breaking:** To use `removeNamespaces`, the provided element needs to be replaced by the returned element. Also, the input element of the function is modified. 

--- a/src/client/src/main/java/org/niis/xrd4j/client/LoadBalancedSOAPClient.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/LoadBalancedSOAPClient.java
@@ -29,6 +29,8 @@ import org.niis.xrd4j.common.member.ProducerMember;
 import org.niis.xrd4j.common.message.ServiceRequest;
 import org.niis.xrd4j.common.message.ServiceResponse;
 
+import org.w3c.dom.NodeList;
+
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
 
@@ -70,8 +72,8 @@ public interface LoadBalancedSOAPClient {
      * that was sent.
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse send(ServiceRequest request, ServiceRequestSerializer serializer,
-                         ServiceResponseDeserializer deserializer) throws SOAPException;
+    <T1, T2> ServiceResponse<T1, T2> send(ServiceRequest<T1> request, ServiceRequestSerializer<T1> serializer,
+                         ServiceResponseDeserializer<T1, T2> deserializer) throws SOAPException;
 
     /**
      * Calls listClients meta service and retrieves list of all the potential
@@ -100,7 +102,7 @@ public interface LoadBalancedSOAPClient {
      * @return ServiceResponse that holds a list of ProducerMember objects
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse listMethods(ServiceRequest request) throws SOAPException;
+    ServiceResponse<String, List<ProducerMember>> listMethods(ServiceRequest<String> request) throws SOAPException;
 
     /**
      * Calls allowedMethods meta service that lists all the services by a
@@ -112,7 +114,7 @@ public interface LoadBalancedSOAPClient {
      * @return ServiceResponse that holds a list of ProducerMember objects
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse allowedMethods(ServiceRequest request) throws SOAPException;
+    ServiceResponse<String, List<ProducerMember>> allowedMethods(ServiceRequest<String> request) throws SOAPException;
 
     /**
      * Calls getSecurityServerMetrics monitoring service that returns a data set
@@ -124,6 +126,6 @@ public interface LoadBalancedSOAPClient {
      * data
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse getSecurityServerMetrics(ServiceRequest request, String url) throws SOAPException;
+    ServiceResponse<String, NodeList> getSecurityServerMetrics(ServiceRequest<String> request, String url) throws SOAPException;
 
 }

--- a/src/client/src/main/java/org/niis/xrd4j/client/LoadBalancedSOAPClientImpl.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/LoadBalancedSOAPClientImpl.java
@@ -31,6 +31,7 @@ import org.niis.xrd4j.common.message.ServiceResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
 
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
@@ -94,6 +95,8 @@ public class LoadBalancedSOAPClientImpl implements LoadBalancedSOAPClient {
      * fails. Serialization and deserialization from/to SOAPMessage is done
      * inside the method.
      *
+     * @param <T1> runtime type of the request data
+     * @param <T2> runtime type of the response data
      * @param request the ServiceRequest object to be sent
      * @param serializer the ServiceRequestSerializer object that serializes the
      * request to SOAPMessage
@@ -104,8 +107,8 @@ public class LoadBalancedSOAPClientImpl implements LoadBalancedSOAPClient {
      * @throws SOAPException if there's a SOAP error
      */
     @Override
-    public ServiceResponse send(final ServiceRequest request, final ServiceRequestSerializer serializer,
-                                final ServiceResponseDeserializer deserializer) throws SOAPException {
+    public <T1, T2> ServiceResponse<T1, T2> send(final ServiceRequest<T1> request, final ServiceRequestSerializer<T1> serializer,
+                                final ServiceResponseDeserializer<T1, T2> deserializer) throws SOAPException {
         return this.soapClient.send(request, this.getTargetUrl(), serializer, deserializer);
     }
 
@@ -143,7 +146,7 @@ public class LoadBalancedSOAPClientImpl implements LoadBalancedSOAPClient {
      * @throws SOAPException if there's a SOAP error
      */
     @Override
-    public ServiceResponse listMethods(final ServiceRequest request) throws SOAPException {
+    public ServiceResponse<String, List<ProducerMember>> listMethods(final ServiceRequest<String> request) throws SOAPException {
         return this.soapClient.listMethods(request, this.getTargetUrl());
     }
 
@@ -158,7 +161,7 @@ public class LoadBalancedSOAPClientImpl implements LoadBalancedSOAPClient {
      * @throws SOAPException if there's a SOAP error
      */
     @Override
-    public ServiceResponse allowedMethods(final ServiceRequest request) throws SOAPException {
+    public ServiceResponse<String, List<ProducerMember>> allowedMethods(final ServiceRequest<String> request) throws SOAPException {
         return this.soapClient.allowedMethods(request, this.getTargetUrl());
     }
 
@@ -173,7 +176,7 @@ public class LoadBalancedSOAPClientImpl implements LoadBalancedSOAPClient {
      * @throws SOAPException if there's a SOAP error
      */
     @Override
-    public ServiceResponse getSecurityServerMetrics(final ServiceRequest request, final String url) throws SOAPException {
+    public ServiceResponse<String, NodeList> getSecurityServerMetrics(final ServiceRequest<String> request, final String url) throws SOAPException {
         return this.soapClient.getSecurityServerMetrics(request, this.getTargetUrl());
     }
 

--- a/src/client/src/main/java/org/niis/xrd4j/client/SOAPClient.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/SOAPClient.java
@@ -29,6 +29,8 @@ import org.niis.xrd4j.common.member.ProducerMember;
 import org.niis.xrd4j.common.message.ServiceRequest;
 import org.niis.xrd4j.common.message.ServiceResponse;
 
+import org.w3c.dom.NodeList;
+
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPMessage;
 
@@ -61,9 +63,12 @@ public interface SOAPClient {
      * if sending the message fails. Serialization and deserialization from/to
      * SOAPMessage is done inside the method.
      *
+     * @param <T1> runtime type of the request data
+     * @param <T2> runtime type of the response data
      * @param request the ServiceRequest object to be sent
      * @param url URL that identifies where the message should be sent
      * @param serializer the ServiceRequestSerializer object that serializes the
+
      * request to SOAPMessage
      * @param deserializer the ServiceResponseDeserializer object that
      * deserializes SOAPMessage response to ServiceResponse
@@ -71,8 +76,8 @@ public interface SOAPClient {
      * that was sent.
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse send(ServiceRequest request, String url, ServiceRequestSerializer serializer,
-                         ServiceResponseDeserializer deserializer) throws SOAPException;
+    <T1, T2> ServiceResponse<T1, T2> send(ServiceRequest<T1> request, String url, ServiceRequestSerializer<T1> serializer,
+                         ServiceResponseDeserializer<T1, T2> deserializer) throws SOAPException;
 
     /**
      * Calls listClients meta service and retrieves list of all the potential
@@ -104,7 +109,7 @@ public interface SOAPClient {
      * @return ServiceResponse that holds a list of ProducerMember objects
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse listMethods(ServiceRequest request, String url) throws SOAPException;
+    ServiceResponse<String, List<ProducerMember>> listMethods(ServiceRequest<String> request, String url) throws SOAPException;
 
     /**
      * Calls allowedMethods meta service that lists all the services by a
@@ -117,7 +122,7 @@ public interface SOAPClient {
      * @return ServiceResponse that holds a list of ProducerMember objects
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse allowedMethods(ServiceRequest request, String url) throws SOAPException;
+    ServiceResponse<String, List<ProducerMember>> allowedMethods(ServiceRequest<String> request, String url) throws SOAPException;
 
     /**
      * Calls getSecurityServerMetrics monitoring service that returns a data set
@@ -129,5 +134,5 @@ public interface SOAPClient {
      * data
      * @throws SOAPException if there's a SOAP error
      */
-    ServiceResponse getSecurityServerMetrics(ServiceRequest request, String url) throws SOAPException;
+    ServiceResponse<String, NodeList> getSecurityServerMetrics(ServiceRequest<String> request, String url) throws SOAPException;
 }

--- a/src/client/src/main/java/org/niis/xrd4j/client/deserializer/ServiceResponseDeserializer.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/deserializer/ServiceResponseDeserializer.java
@@ -30,9 +30,11 @@ import jakarta.xml.soap.SOAPMessage;
  * This class defines an interface for deserializing SOAPMessage objects
  * to ServiceResponse objects.
  *
+ * @param <T1> runtime type of the request data
+ * @param <T2> runtime type of the response data
  * @author Petteri Kivimäki
  */
-public interface ServiceResponseDeserializer {
+public interface ServiceResponseDeserializer<T1, T2> {
 
     /**
      * Deserializes the given SOAPMessage object to ServiceResponse object.
@@ -40,7 +42,7 @@ public interface ServiceResponseDeserializer {
      * @return ServiceResponse object that represents the given
      * SOAPMessage object; if the operation fails, null is returned
      */
-    ServiceResponse deserialize(SOAPMessage message);
+    ServiceResponse<T1, T2> deserialize(SOAPMessage message);
 
     /**
      * Deserializes the given SOAPMessage object to ServiceResponse object.
@@ -52,7 +54,7 @@ public interface ServiceResponseDeserializer {
      * @return ServiceResponse object that represents the given
      * SOAPMessage object; if the operation fails, null is returned
      */
-    ServiceResponse deserialize(SOAPMessage message, String producerNamespaceURI);
+    ServiceResponse<T1, T2> deserialize(SOAPMessage message, String producerNamespaceURI);
 
     /**
      * Deserializes the given SOAPMessage object to ServiceResponse object.
@@ -65,5 +67,5 @@ public interface ServiceResponseDeserializer {
      * @return ServiceResponse object that represents the given
      * SOAPMessage object; if the operation fails, null is returned
      */
-    ServiceResponse deserialize(SOAPMessage message, String producerNamespaceURI, boolean processingWrappers);
+    ServiceResponse<T1, T2> deserialize(SOAPMessage message, String producerNamespaceURI, boolean processingWrappers);
 }

--- a/src/client/src/main/java/org/niis/xrd4j/client/serializer/AbstractServiceRequestSerializer.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/serializer/AbstractServiceRequestSerializer.java
@@ -46,9 +46,10 @@ import jakarta.xml.soap.SOAPMessage;
  * application specific request object to SOAP body's request element. This
  * class takes care of adding all the required SOAP headers.
  *
+ * @param <T> runtime type of the request data
  * @author Petteri Kivimäki
  */
-public abstract class AbstractServiceRequestSerializer extends AbstractHeaderSerializer implements ServiceRequestSerializer {
+public abstract class AbstractServiceRequestSerializer<T> extends AbstractHeaderSerializer implements ServiceRequestSerializer<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractServiceRequestSerializer.class);
 
@@ -64,7 +65,7 @@ public abstract class AbstractServiceRequestSerializer extends AbstractHeaderSer
      * @param envelope SOAPMessage's SOAPEnvelope object
      * @throws SOAPException if there's a SOAP error
      */
-    protected abstract void serializeRequest(ServiceRequest request, SOAPElement soapRequest, SOAPEnvelope envelope) throws SOAPException;
+    protected abstract void serializeRequest(ServiceRequest<T> request, SOAPElement soapRequest, SOAPEnvelope envelope) throws SOAPException;
 
     /**
      * Serializes the given ServiceRequest to SOAPMessage.
@@ -74,7 +75,7 @@ public abstract class AbstractServiceRequestSerializer extends AbstractHeaderSer
      * operation fails
      */
     @Override
-    public final SOAPMessage serialize(final ServiceRequest request) {
+    public final SOAPMessage serialize(final ServiceRequest<T> request) {
         try {
             LOGGER.debug("Serialize ServiceRequest message to SOAP.");
             MessageFactory myMsgFct = MessageFactory.newInstance();
@@ -104,7 +105,7 @@ public abstract class AbstractServiceRequestSerializer extends AbstractHeaderSer
      * @throws SOAPException if there's a SOAP error
      * @throws XRd4JException if there's a XRd4J error
      */
-    private void serializeBody(final ServiceRequest request) throws SOAPException, XRd4JException {
+    private void serializeBody(final ServiceRequest<T> request) throws SOAPException, XRd4JException {
         LOGGER.debug("Generate SOAP body.");
         LOGGER.debug("Use producer namespace \"{}\".", request.getProducer().getNamespaceUrl());
         // Body - Start

--- a/src/client/src/main/java/org/niis/xrd4j/client/serializer/DefaultServiceRequestSerializer.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/serializer/DefaultServiceRequestSerializer.java
@@ -40,7 +40,7 @@ import jakarta.xml.soap.SOAPException;
  *
  * @author Petteri Kivim'ki
  */
-public class DefaultServiceRequestSerializer extends AbstractServiceRequestSerializer {
+public class DefaultServiceRequestSerializer extends AbstractServiceRequestSerializer<String> {
 
     /**
      * Empty implementation.
@@ -53,7 +53,7 @@ public class DefaultServiceRequestSerializer extends AbstractServiceRequestSeria
      * @throws SOAPException if there's a SOAP error
      */
     @Override
-    protected void serializeRequest(ServiceRequest request, SOAPElement soapRequest, SOAPEnvelope envelope) throws SOAPException {
+    protected void serializeRequest(ServiceRequest<String> request, SOAPElement soapRequest, SOAPEnvelope envelope) throws SOAPException {
         // This class can be used for serializing meta service calls that don't
         // have any request parameters.
     }

--- a/src/client/src/main/java/org/niis/xrd4j/client/serializer/ServiceRequestSerializer.java
+++ b/src/client/src/main/java/org/niis/xrd4j/client/serializer/ServiceRequestSerializer.java
@@ -30,15 +30,16 @@ import jakarta.xml.soap.SOAPMessage;
  * This class defines an interface for serializing ServiceRequest objects
  * to SOAPMessage objects.
  *
+ * @param <T> runtime type of the request data
  * @author Petteri Kivimäki
  */
 @FunctionalInterface
-public interface ServiceRequestSerializer {
+public interface ServiceRequestSerializer<T> {
 
     /**
      * Serializes the given ServiceRequest object to SOAPMessage object.
      * @param request ServiceRequest to be serialized
      * @return SOAPMessage representing the given ServiceRequest
      */
-    SOAPMessage serialize(ServiceRequest request);
+    SOAPMessage serialize(ServiceRequest<T> request);
 }

--- a/src/common/src/main/java/org/niis/xrd4j/common/member/ProducerMember.java
+++ b/src/common/src/main/java/org/niis/xrd4j/common/member/ProducerMember.java
@@ -24,9 +24,11 @@ package org.niis.xrd4j.common.member;
 
 import org.niis.xrd4j.common.exception.XRd4JException;
 import org.niis.xrd4j.common.util.Constants;
+import org.niis.xrd4j.common.util.Pair;
 import org.niis.xrd4j.common.util.ValidationHelper;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * This class represent X-Road producer member that produces services to
@@ -63,7 +65,10 @@ public class ProducerMember extends AbstractMember implements Serializable {
      * @param xRoadInstance identifier of this X-Road instance
      * @param serviceCode unique service code
      * @throws XRd4JException if there's a XRd4J error
+     * @deprecated This constructor is deprecated and will be removed in future versions.
+     * X-Road no longer supports Central Services so this identifier does not make sense anymore.
      */
+    @Deprecated
     public ProducerMember(String xRoadInstance, String serviceCode) throws XRd4JException {
         super(xRoadInstance);
         this.serviceCode = serviceCode;
@@ -78,12 +83,14 @@ public class ProducerMember extends AbstractMember implements Serializable {
      * @param serviceCode code that uniquely identifies a service offered by
      * this member
      * @throws XRd4JException if there's a XRd4J error
+     * @deprecated This constructor is deprecated and will be removed in future versions.
+     * This creates too much ambiguity as we could have either no subsystem described or no service code described.
      */
+    @Deprecated
     public ProducerMember(String xRoadInstance, String memberClass, String memberCode, String serviceCode) throws XRd4JException {
         super(xRoadInstance, memberClass, memberCode);
         this.serviceCode = serviceCode;
         ValidationHelper.validateStrNotNullOrEmpty(serviceCode, Constants.NS_ID_ELEM_SERVICE_CODE);
-
     }
 
     /**
@@ -100,7 +107,10 @@ public class ProducerMember extends AbstractMember implements Serializable {
     public ProducerMember(String xRoadInstance, String memberClass, String memberCode, String subsystemCode, String serviceCode) throws XRd4JException {
         super(xRoadInstance, memberClass, memberCode, subsystemCode);
         this.serviceCode = serviceCode;
-        ValidationHelper.validateStrNotNullOrEmpty(serviceCode, Constants.NS_ID_ELEM_SERVICE_CODE);
+        ValidationHelper.validateAtLeastOneNotNullOrEmpty(
+                Arrays.asList(
+                        new Pair(Constants.NS_ID_ELEM_SERVICE_CODE, serviceCode),
+                        new Pair(Constants.NS_ID_ELEM_SUBSYSTEM_CODE, subsystemCode)));
     }
 
     /**

--- a/src/common/src/main/java/org/niis/xrd4j/common/util/Pair.java
+++ b/src/common/src/main/java/org/niis/xrd4j/common/util/Pair.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ * Copyright © 2018 Nordic Institute for Interoperability Solutions (NIIS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.niis.xrd4j.common.util;
+
+/**
+ * A pair element containing a key and value as a String.
+ */
+public class Pair {
+    private String key;
+    private String value;
+
+    public Pair(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/common/src/main/java/org/niis/xrd4j/common/util/ValidationHelper.java
+++ b/src/common/src/main/java/org/niis/xrd4j/common/util/ValidationHelper.java
@@ -24,6 +24,9 @@ package org.niis.xrd4j.common.util;
 
 import org.niis.xrd4j.common.exception.XRd4JException;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * This class offers some helper methods for validation.
  *
@@ -71,5 +74,18 @@ public final class ValidationHelper {
     public static void validateStrNotNullOrEmpty(String str, String name) throws XRd4JException {
         ValidationHelper.validateNotNull(str, name);
         ValidationHelper.validateStrNotEmpty(str, name);
+    }
+
+    /**
+     * Checks that there is at least one non-null / non-empty value in the
+     * provided list.
+     * @param pairs A list of {@link Pair} objects to validate
+     * @throws XRd4JException if all pair values are null or empty
+     */
+    public static void validateAtLeastOneNotNullOrEmpty(List<Pair> pairs) throws XRd4JException {
+        if (pairs.stream().noneMatch(p -> p.getValue() != null && !p.getValue().isEmpty())) {
+            String keys = pairs.stream().map(Pair::getKey).collect(Collectors.joining(","));
+            throw new XRd4JException("At least one of " + keys + "must not be empty");
+        }
     }
 }

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ org-mockito-mockitoCore = { module = "org.mockito:mockito-core", version = "5.14
 licenseGradlePlugin = { module = "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin", version = "0.16.1" }
 dependencyCheckGradlePlugin = { module = "org.owasp:dependency-check-gradle", version = "10.0.4" }
 javadocAggregateGradlePlugin = { module = "io.freefair.gradle:maven-plugin", version = "8.10" }
-sonarqubeGradlePlugin = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version="5.1.0.4882" }
+sonarqubeGradlePlugin = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version="6.2.0.5505" }
 
 [bundles]
 testImplementation = [ "junit-jupiter", "org-slf4j-slf4jApi", "org-apache-logging-log4j-log4jSlf4j2Impl", "org-apache-logging-log4j-log4jCore" ]


### PR DESCRIPTION
Improves generic definitions on functions.

Also relaxed some checks on ProducerMember construction to allow identifiers with only subsystem to be used.